### PR TITLE
Convert internal message format to TRAPI 1.1

### DIFF
--- a/frontend/src/components/header/Header.jsx
+++ b/frontend/src/components/header/Header.jsx
@@ -116,6 +116,7 @@ export default function Header({ setUser }) {
       <Toolbar id="headerToolbar">
         <Link to="/" id="robokopBrand">{brandConfig.title}</Link>
         <Link to="/questions">Question Library</Link>
+        <Link to="/answer">Answer Viewer</Link>
         <div className="grow" />
         {brandConfig.brand === 'robokop' && (
           <>

--- a/frontend/src/pages/answer/Answer.jsx
+++ b/frontend/src/pages/answer/Answer.jsx
@@ -81,7 +81,7 @@ export default function Answer() {
     }
 
     try {
-      answerResponseJSON.message.query_graph = queryGraphUtils.standardize(answerResponseJSON.message.query_graph);
+      answerResponseJSON.message.query_graph = queryGraphUtils.toCurrentTRAPI(answerResponseJSON.message.query_graph);
       try {
         answerStore.initialize(answerResponseJSON.message, updateDisplayState);
         pageStatus.setSuccess();
@@ -152,7 +152,7 @@ export default function Answer() {
         const errors = trapiUtils.validateMessage(msg);
         if (!errors.length) {
           try {
-            msg.message.query_graph = queryGraphUtils.standardize(msg.message.query_graph);
+            msg.message.query_graph = queryGraphUtils.toCurrentTRAPI(msg.message.query_graph);
             try {
               idbSet('quick_message', JSON.stringify(msg));
               answerStore.initialize(msg.message, updateDisplayState);

--- a/frontend/src/pages/answer/fullKg/KgFull.jsx
+++ b/frontend/src/pages/answer/fullKg/KgFull.jsx
@@ -47,11 +47,11 @@ export default function KgFull({ message }) {
       context.beginPath();
       context.moveTo(d.x + 5, d.y);
       context.arc(d.x, d.y, 5, 0, 2 * Math.PI);
-      if (d.category && Array.isArray(d.category)) {
-        d.category = kgUtils.getRankedCategories(hierarchies, d.category);
+      if (d.categories && Array.isArray(d.categories)) {
+        d.categories = kgUtils.getRankedCategories(hierarchies, d.categories);
       }
-      context.strokeStyle = colorMap((d.category && d.category[0]) || 'unknown');
-      context.fillStyle = colorMap((d.category && d.category[0]) || 'unknown');
+      context.strokeStyle = colorMap((d.categories && d.categories[0]) || 'unknown');
+      context.fillStyle = colorMap((d.categories && d.categories[0]) || 'unknown');
       context.fill();
       context.stroke();
     }

--- a/frontend/src/pages/answer/kgBubble/KgBubble.jsx
+++ b/frontend/src/pages/answer/kgBubble/KgBubble.jsx
@@ -75,7 +75,7 @@ export default function KgBubble({
           .call(dragUtils.dragNode(simulation))
           .call((n) => n.append('circle')
             .attr('r', (d) => getNodeRadius(d.count))
-            .attr('fill', (d) => colorMap((d.category && d.category[0]) || 'unknown'))
+            .attr('fill', (d) => colorMap((d.categories && d.categories[0]) || 'unknown'))
             .call((nCircle) => nCircle.append('title')
               .text((d) => d.name)))
           .call((n) => n.append('text')

--- a/frontend/src/pages/answer/queryGraph/QueryGraph.jsx
+++ b/frontend/src/pages/answer/queryGraph/QueryGraph.jsx
@@ -110,7 +110,7 @@ export default function QueryGraph({ query_graph }) {
           .call(dragUtils.dragNode(simulation))
           .call((n) => n.append('circle')
             .attr('r', nodeRadius)
-            .attr('fill', (d) => colorMap((d.category && d.category[0]) || 'unknown'))
+            .attr('fill', (d) => colorMap((d.categories && d.categories[0]) || 'unknown'))
             .call((nCircle) => nCircle.append('title')
               .text((d) => d.name)))
           .call((n) => n.append('text')
@@ -150,9 +150,9 @@ export default function QueryGraph({ query_graph }) {
                 .attr('pointer-events', 'none')
                 .attr('xlink:href', (d) => `#edge${d.id}`)
                 .attr('startOffset', '50%')
-                .text((d) => (d.predicate ? d.predicate.map((p) => stringUtils.displayPredicate(p)).join(' or ') : '')))
+                .text((d) => (d.predicates ? d.predicates.map((p) => stringUtils.displayPredicate(p)).join(' or ') : '')))
             .call((eLabel) => eLabel.append('title')
-              .text((d) => (d.predicate ? d.predicate.map((p) => stringUtils.displayPredicate(p)).join(' or ') : ''))));
+              .text((d) => (d.predicates ? d.predicates.map((p) => stringUtils.displayPredicate(p)).join(' or ') : ''))));
 
     simulation.alpha(1).restart();
   }

--- a/frontend/src/pages/answer/queryGraph/QueryGraph.jsx
+++ b/frontend/src/pages/answer/queryGraph/QueryGraph.jsx
@@ -8,6 +8,7 @@ import Paper from '@material-ui/core/Paper';
 import BiolinkContext from '~/context/biolink';
 import dragUtils from '~/utils/d3/drag';
 import graphUtils from '~/utils/d3/graph';
+import edgeUtils from '~/utils/d3/edges';
 import queryGraphUtils from '~/utils/queryGraph';
 import stringUtils from '~/utils/strings';
 
@@ -124,7 +125,7 @@ export default function QueryGraph({ query_graph }) {
             })
             .each(graphUtils.ellipsisOverflow));
 
-    edges = queryGraphUtils.addEdgeCurveProperties(edges);
+    edges = edgeUtils.addEdgeCurveProperties(edges);
     edge = edge.data(edges)
       .enter()
         .append('g')

--- a/frontend/src/pages/answer/resultsTable/ResultExplorer.jsx
+++ b/frontend/src/pages/answer/resultsTable/ResultExplorer.jsx
@@ -8,6 +8,7 @@ import Paper from '@material-ui/core/Paper';
 import BiolinkContext from '~/context/biolink';
 import dragUtils from '~/utils/d3/drag';
 import graphUtils from '~/utils/d3/graph';
+import edgeUtils from '~/utils/d3/edges';
 import stringUtils from '~/utils/strings';
 import queryGraphUtils from '~/utils/queryGraph';
 import ResultMetaData from './ResultMetaData';
@@ -174,7 +175,7 @@ export default function ResultExplorer({ answerStore }) {
           .remove(),
       );
 
-    const edgesWithCurves = queryGraphUtils.addEdgeCurveProperties(edges);
+    const edgesWithCurves = edgeUtils.addEdgeCurveProperties(edges);
     edge.current = edge.current.data(edgesWithCurves, (d) => d.id)
       .join(
         (enter) => enter

--- a/frontend/src/pages/answer/resultsTable/ResultExplorer.jsx
+++ b/frontend/src/pages/answer/resultsTable/ResultExplorer.jsx
@@ -10,7 +10,6 @@ import dragUtils from '~/utils/d3/drag';
 import graphUtils from '~/utils/d3/graph';
 import edgeUtils from '~/utils/d3/edges';
 import stringUtils from '~/utils/strings';
-import queryGraphUtils from '~/utils/queryGraph';
 import ResultMetaData from './ResultMetaData';
 
 const nodeRadius = 40;
@@ -201,9 +200,9 @@ export default function ResultExplorer({ answerStore }) {
                   .attr('pointer-events', 'none')
                   .attr('xlink:href', (d) => `#edge${d.id}`)
                   .attr('startOffset', '50%')
-                  .text((d) => (d.predicate ? d.predicate.map((p) => stringUtils.displayPredicate(p)).join(' or ') : '')))
+                  .text((d) => stringUtils.displayPredicate(d.predicate)))
               .call((eLabel) => eLabel.append('title')
-                .text((d) => (d.predicate ? d.predicate.map((p) => stringUtils.displayPredicate(p)).join(' or ') : '')))),
+                .text((d) => (stringUtils.displayPredicate(d.predicate))))),
         (update) => update,
         (exit) => exit
           .remove(),

--- a/frontend/src/pages/answer/useAnswerStore.js
+++ b/frontend/src/pages/answer/useAnswerStore.js
@@ -76,9 +76,6 @@ export default function useAnswerStore() {
             target: kgEdge.object,
             predicate: kgEdge.predicate,
           };
-          if (graphEdge.predicate && !Array.isArray(graphEdge.predicate)) {
-            graphEdge.predicate = [graphEdge.predicate];
-          }
           edges.push(graphEdge);
 
           // EDAM:data_0971 is the publications type

--- a/frontend/src/pages/queryBuilder/graphEditor/QueryGraph.jsx
+++ b/frontend/src/pages/queryBuilder/graphEditor/QueryGraph.jsx
@@ -253,7 +253,7 @@ export default function QueryGraph({
 
     // edge ends need the x and y of their attached nodes
     // must come after simulation
-    const edgesWithCurves = queryGraphUtils.addEdgeCurveProperties(newEdges);
+    const edgesWithCurves = edgeUtils.addEdgeCurveProperties(newEdges);
 
     edge.current = edge.current.data(edgesWithCurves, (d) => d.id)
       .join(

--- a/frontend/src/pages/queryBuilder/jsonEditor/JsonEditor.jsx
+++ b/frontend/src/pages/queryBuilder/jsonEditor/JsonEditor.jsx
@@ -14,6 +14,7 @@ import FileCopyIcon from '@material-ui/icons/FileCopy';
 import SaveIcon from '@material-ui/icons/Save';
 
 import trapiUtils from '~/utils/trapi';
+import queryGraphUtils from '~/utils/queryGraph';
 import usePageStatus from '~/stores/usePageStatus';
 import AlertContext from '~/context/alert';
 import QueryBuilderContext from '~/context/queryBuilder';
@@ -56,7 +57,11 @@ export default function JsonEditor({ show, close }) {
           if (graph.message && graph.message.results) {
             delete graph.message.results;
           }
-          setErrorMessages(trapiUtils.validateMessage(graph));
+          const errors = trapiUtils.validateMessage(graph);
+          setErrorMessages(errors);
+          if (!errors.length) {
+            graph.message.query_graph = queryGraphUtils.toCurrentTRAPI(graph.message.query_graph);
+          }
           updateLocalMessage(graph);
         } catch (err) {
           displayAlert('error', 'Failed to read this query graph. Are you sure this is valid JSON?');

--- a/frontend/src/pages/queryBuilder/textEditor/textEditorRow/NodeSelector.jsx
+++ b/frontend/src/pages/queryBuilder/textEditor/textEditorRow/NodeSelector.jsx
@@ -14,8 +14,8 @@ import fetchCuries from '~/utils/fetchCuries';
 import highlighter from '~/utils/d3/highlighter';
 
 function isValidNode(properties) {
-  return (properties.category && properties.category.length) ||
-    (properties.id && properties.id.length);
+  return (properties.categories && properties.categories.length) ||
+    (properties.ids && properties.ids.length);
 }
 
 /**
@@ -75,25 +75,25 @@ export default function NodeSelector({
         includedCategories = includedCategories.flatMap((category) => (
           [
             {
-              category: [category],
+              categories: [category],
               name: strings.displayCategory(category),
             },
             {
-              category: [category],
+              categories: [category],
               name: strings.setify(category),
               is_set: true,
             },
           ]
         ));
       } else {
-        includedCategories = includedCategories.map((category) => ({ category: [category], name: strings.displayCategory(category) }));
+        includedCategories = includedCategories.map((category) => ({ categories: [category], name: strings.displayCategory(category) }));
       }
       newOptions.push(...includedCategories);
     }
     // fetch matching curies from external services
     if (includeCuries && searchTerm.length > 3) {
       if (searchTerm.includes(':')) { // user is typing a specific curie
-        newOptions.push({ name: searchTerm, id: searchTerm });
+        newOptions.push({ name: searchTerm, ids: searchTerm });
       } else {
         const curies = await fetchCuries(searchTerm, displayAlert);
         newOptions.push(...curies);
@@ -128,12 +128,12 @@ export default function NodeSelector({
     if (opt.name) {
       return label + opt.name;
     }
-    if (opt.id && Array.isArray(opt.id) && opt.id.length) {
-      return label + opt.id.join(', ');
+    if (opt.ids && Array.isArray(opt.ids) && opt.ids.length) {
+      return label + opt.ids.join(', ');
     }
-    if (opt.category && Array.isArray(opt.category)) {
-      if (opt.category.length) {
-        return label + opt.category.join(', ');
+    if (opt.categories && Array.isArray(opt.categories)) {
+      if (opt.categories.length) {
+        return label + opt.categories.join(', ');
       }
       return `${label} Something`;
     }

--- a/frontend/src/pages/queryBuilder/textEditor/textEditorRow/PredicateSelector.jsx
+++ b/frontend/src/pages/queryBuilder/textEditor/textEditorRow/PredicateSelector.jsx
@@ -34,8 +34,8 @@ export default function PredicateSelector({ id }) {
     const objectNode = query_graph.nodes[edge.object];
 
     // get list of categories from each node
-    const subjectCategories = getCategories(subjectNode.category);
-    const objectCategories = getCategories(objectNode.category);
+    const subjectCategories = getCategories(subjectNode.categories);
+    const objectCategories = getCategories(objectNode.categories);
 
     // get hierarchies of all involved node categories
     const subjectNodeCategoryHierarchy = subjectCategories.flatMap((subjectCategory) => biolink.hierarchies[subjectCategory]);
@@ -56,20 +56,20 @@ export default function PredicateSelector({ id }) {
     getFilteredPredicateList,
     [
       // recompute if node categories change
-      JSON.stringify(query_graph.nodes[edge.subject].category),
-      JSON.stringify(query_graph.nodes[edge.object].category),
+      JSON.stringify(query_graph.nodes[edge.subject].categories),
+      JSON.stringify(query_graph.nodes[edge.object].categories),
       biolink,
     ],
   ) || [];
 
-  function editPredicate(predicate) {
-    queryBuilder.dispatch({ type: 'editPredicate', payload: { id, predicate } });
+  function editPredicates(predicates) {
+    queryBuilder.dispatch({ type: 'editPredicate', payload: { id, predicates } });
   }
 
   useEffect(() => {
     if (filteredPredicateList.length) {
-      const keptPredicates = (edge.predicate && edge.predicate.filter((p) => filteredPredicateList.indexOf(p) > -1)) || [];
-      editPredicate(keptPredicates);
+      const keptPredicates = (edge.predicates && edge.predicates.filter((p) => filteredPredicateList.indexOf(p) > -1)) || [];
+      editPredicates(keptPredicates);
     }
   }, [filteredPredicateList]);
 
@@ -77,8 +77,8 @@ export default function PredicateSelector({ id }) {
     <Autocomplete
       options={filteredPredicateList}
       className={`textEditorSelector highlight-${id}`}
-      value={edge.predicate || []}
-      onChange={(e, value) => editPredicate(value)}
+      value={edge.predicates || []}
+      onChange={(e, value) => editPredicates(value)}
       renderInput={(params) => (
         <TextField
           {...params}

--- a/frontend/src/pages/queryBuilder/useQueryBuilder.js
+++ b/frontend/src/pages/queryBuilder/useQueryBuilder.js
@@ -8,15 +8,15 @@ import queryGraphUtils from '~/utils/queryGraph';
 
 function getDefaultNode() {
   return {
-    category: [],
-    id: [],
+    categories: [],
+    ids: [],
   };
 }
 function getDefaultEdge(subject, object) {
   return {
     subject: subject || '',
     object: object || '',
-    predicate: ['biolink:related_to'],
+    predicates: ['biolink:related_to'],
   };
 }
 
@@ -63,8 +63,8 @@ function reducer(state, action) {
       break;
     }
     case 'editPredicate': {
-      const { id, predicate } = action.payload;
-      state.message.message.query_graph.edges[id].predicate = predicate;
+      const { id, predicates } = action.payload;
+      state.message.message.query_graph.edges[id].predicates = predicates;
       break;
     }
     case 'deleteEdge': {

--- a/frontend/src/pages/queryBuilder/useQueryBuilder.js
+++ b/frontend/src/pages/queryBuilder/useQueryBuilder.js
@@ -106,7 +106,7 @@ function reducer(state, action) {
       break;
     }
     case 'saveGraph': {
-      state.message.message.query_graph = queryGraphUtils.standardize(action.payload.message.query_graph);
+      state.message.message.query_graph = queryGraphUtils.toCurrentTRAPI(action.payload.message.query_graph);
       state.rootNode = queryBuilderUtils.getRootNode(state.message.message.query_graph);
       break;
     }

--- a/frontend/src/utils/d3/edges.js
+++ b/frontend/src/utils/d3/edges.js
@@ -147,9 +147,9 @@ function enter(edge) {
           .attr('pointer-events', 'none')
           .attr('xlink:href', (d) => `#edge${d.id}`)
           .attr('startOffset', '50%')
-          .text((d) => (d.predicate ? d.predicate.map((p) => strings.displayPredicate(p)).join(', ') : '')))
+          .text((d) => (d.predicates ? d.predicates.map((p) => strings.displayPredicate(p)).join(', ') : '')))
       .call((eLabel) => eLabel.append('title')
-        .text((d) => (d.predicate ? d.predicate.map((p) => strings.displayPredicate(p)).join(', ') : ''))))
+        .text((d) => (d.predicates ? d.predicates.map((p) => strings.displayPredicate(p)).join(', ') : ''))))
     // source edge end circle
     .call((e) => e.append('circle')
       .attr('r', 5)
@@ -228,13 +228,13 @@ function enter(edge) {
 function update(edge) {
   return edge
     .call((e) => e.select('title')
-      .text((d) => (d.predicate ? d.predicate.map((p) => strings.displayPredicate(p)).join(', ') : '')))
+      .text((d) => (d.predicates ? d.predicates.map((p) => strings.displayPredicate(p)).join(', ') : '')))
     .call((e) => e.select('.edgePath')
       // .attr('stroke-width', (d) => d.strokeWidth)
       .attr('marker-end', (d) => (graphUtils.shouldShowArrow(d) ? 'url(#arrow)' : '')))
     .call((e) => e.select('text')
       .select('textPath')
-        .text((d) => (d.predicate ? d.predicate.map((p) => strings.displayPredicate(p)).join(', ') : '')));
+        .text((d) => (d.predicates ? d.predicates.map((p) => strings.displayPredicate(p)).join(', ') : '')));
     //   .attr('dy', (d) => -d.strokeWidth));
 }
 

--- a/frontend/src/utils/d3/edges.js
+++ b/frontend/src/utils/d3/edges.js
@@ -28,6 +28,95 @@ const editTextOffset = {
 };
 
 /**
+ * Find curve id regardless of node id order
+ * @param {object[]} edgeCurves - list of edges with curve properties
+ * @param {string} id - `{nodeId}--{nodeId}`
+ * @returns {string} `{nodeId}--{nodeId}`
+ */
+function findCurveId(edgeCurves, id) {
+  const [subject, object] = id.split('--');
+  const curveId = Object.keys(edgeCurves).find((curve) => {
+    const nodeIds = curve.split('--');
+    if (nodeIds.indexOf(subject) > -1 && nodeIds.indexOf(object) > -1) {
+      return true;
+    }
+    return false;
+  });
+  return curveId;
+}
+
+const edgeCurveProps = {
+  get: (edgeCurves, id) => {
+    const curveId = findCurveId(edgeCurves, id);
+    let flip = false;
+    if (curveId) {
+      // n0--n1 != n1--n0
+      // we need to flip in order to have all edges right side up
+      if (curveId !== id) {
+        flip = true;
+      }
+      // return existing edge curve props
+      return { indices: edgeCurves[curveId], flip };
+    }
+    // return new edge curve props
+    return { indices: [], flip };
+  },
+  set: (edgeCurves, id, val) => {
+    const curveId = findCurveId(edgeCurves, id);
+    if (curveId) {
+      edgeCurves[curveId] = val;
+    } else {
+      edgeCurves[id] = val;
+    }
+    return true;
+  },
+};
+
+/**
+ * Add numEdges, index, and strokeWidth to edge objects
+ *
+ * **Must modify the existing edges array to keep the same reference for d3**
+ * @param {object[]} edges - list of graph edges
+ * @returns {object[]} list of edges with properties for d3 curves
+ */
+function addEdgeCurveProperties(edges) {
+  const curveProps = new Proxy({}, edgeCurveProps);
+  edges.forEach((e, i) => {
+    const curve = curveProps[`${e.source.id}--${e.target.id}`];
+    curve.indices.push(i);
+    curveProps[`${e.source.id}--${e.target.id}`] = curve.indices;
+  });
+  edges.forEach((e, i) => {
+    const curve = curveProps[`${e.source.id}--${e.target.id}`];
+    e.numEdges = curve.indices.length;
+    const edgeIndex = curve.indices.indexOf(i);
+    e.index = edgeIndex;
+    // if an even number of edges, move first middle edge to outside
+    // to keep edges symmetrical
+    if (curve.indices.length % 2 === 0 && edgeIndex === 0) {
+      e.index = curve.indices.length - 1;
+    }
+    // if not the first index (0)
+    if (edgeIndex) {
+      // all even index should be one less and odd indices
+      // should be flipped
+      const edgeL = edgeIndex % 2;
+      if (!edgeL) {
+        e.index -= 1;
+      } else {
+        e.index = -e.index;
+      }
+    }
+    // flip curve on any inverse edges
+    if (curve.flip) {
+      e.index = -e.index;
+    }
+    e.strokeWidth = '3';
+  });
+  return edges;
+}
+
+/**
  * Handle creation of edges
  * @param {obj} edge - d3 edge object
  */
@@ -278,6 +367,8 @@ export default {
   enter,
   update,
   exit,
+
+  addEdgeCurveProperties,
 
   attachEdgeClick,
   attachDeleteClick,

--- a/frontend/src/utils/d3/graph.js
+++ b/frontend/src/utils/d3/graph.js
@@ -156,7 +156,7 @@ function isInside(x, y, cx, cy, r) {
  * @returns {str} url(#arrow) or empty string
  */
 function shouldShowArrow(edge) {
-  return edge.predicate && edge.predicate.findIndex((p) => p !== 'biolink:related_to') > -1;
+  return edge.predicates && edge.predicates.findIndex((p) => p !== 'biolink:related_to') > -1;
 }
 
 /**

--- a/frontend/src/utils/d3/nodes.js
+++ b/frontend/src/utils/d3/nodes.js
@@ -43,7 +43,7 @@ function enter(node, args) {
     .call((nodeCircle) => nodeCircle.append('circle')
       .attr('class', (d) => `nodeCircle node-${d.id}`)
       .attr('r', nodeRadius)
-      .attr('fill', (d) => colorMap((d.category && d.category[0]) || 'unknown'))
+      .attr('fill', (d) => colorMap((d.categories && d.categories[0]) || 'unknown'))
       .style('cursor', 'pointer')
       .call((n) => n.append('title')
         .text((d) => {
@@ -120,7 +120,7 @@ function update(node, args) {
   const { colorMap } = args;
   return node
     .call((n) => n.select('.nodeCircle')
-      .attr('fill', (d) => colorMap((d.category && d.category[0]) || 'unknown')))
+      .attr('fill', (d) => colorMap((d.categories && d.categories[0]) || 'unknown')))
       .style('filter', (d) => (d.is_set ? 'url(#setShadow)' : ''))
       .call((nodeCircle) => nodeCircle.select('title')
         .text((d) => {

--- a/frontend/src/utils/fetchCuries.js
+++ b/frontend/src/utils/fetchCuries.js
@@ -27,8 +27,8 @@ export default async function fetchCuries(entity, displayAlert) {
   // so we use a filter to remove those
   const newOptions = Object.values(normalizationResponse).filter((c) => c).map((c) => ({
     name: c.id.label || c.id.identifier,
-    category: c.type,
-    id: c.id.identifier,
+    categories: c.type,
+    ids: [c.id.identifier],
   }));
 
   return newOptions;

--- a/frontend/src/utils/knowledgeGraph.js
+++ b/frontend/src/utils/knowledgeGraph.js
@@ -23,11 +23,11 @@ function getNodeRadius(width, height, numQNodes, numResults) {
 /**
  * Rank categories based on how specific they are
  * @param {object} hierarchies - all biolink hierarchies
- * @param {array} category - list of categories of a specific node
+ * @param {array} categories - list of categories of a specific node
  * @returns {string[]} list of ranked categories
  */
-function getRankedCategories(hierarchies, category) {
-  const rankedCategories = category.sort((a, b) => {
+function getRankedCategories(hierarchies, categories) {
+  const rankedCategories = categories.sort((a, b) => {
     const aLength = (hierarchies[a] && hierarchies[a].length) || 0;
     const bLength = (hierarchies[b] && hierarchies[b].length) || 0;
     return aLength - bLength;
@@ -54,7 +54,7 @@ function makeDisplayNodes(message, hierarchies) {
             categories = [categories];
           }
           categories = getRankedCategories(hierarchies, categories);
-          displayNode.category = categories;
+          displayNode.categories = categories;
           displayNode.name = message.knowledge_graph.nodes[displayNode.id].name;
           displayNode.count = 1;
         } else {
@@ -78,9 +78,9 @@ function getFullDisplay(message) {
     const node = {};
     node.id = nodeId;
     node.name = nodeProps.name;
-    node.category = nodeProps.category;
-    if (node.category && !Array.isArray(node.category)) {
-      node.category = [node.category];
+    node.categories = nodeProps.categories;
+    if (node.categories && !Array.isArray(node.categories)) {
+      node.categories = [node.categories];
     }
     return node;
   });
@@ -89,9 +89,9 @@ function getFullDisplay(message) {
     edge.id = edgeId;
     edge.source = edgeProps.subject;
     edge.target = edgeProps.object;
-    edge.predicate = edgeProps.predicate;
-    if (edge.predicate && !Array.isArray(edge.predicate)) {
-      edge.predicate = [edge.predicate];
+    edge.predicates = edgeProps.predicates;
+    if (edge.predicates && !Array.isArray(edge.predicates)) {
+      edge.predicates = [edge.predicates];
     }
     return edge;
   });

--- a/frontend/src/utils/queryGraph.js
+++ b/frontend/src/utils/queryGraph.js
@@ -12,53 +12,19 @@ function getEmptyGraph() {
 }
 
 /**
- * Convert a list of objects with an "id" property
- * to a dictionary
- * @param {array} list - a list of node or edge objects that each have an ID property
+ * Convert an array of objects with "id" properties
+ * to an object
+ * @param {array} array - a list of objects that each have an ID property
  */
-function listWithIdsToDict(list) {
-  const ret = {};
+function arrayWithIdsToObj(array) {
+  const object = {};
 
-  list.forEach((node) => {
-    ret[node.id] = { ...node };
-    delete ret[node.id].id;
+  array.forEach((item) => {
+    object[item.id] = { ...item };
+    delete object[item.id].id;
   });
 
-  return ret;
-}
-
-/**
- * Convert a dictionary of key-value pairs to a list of objects
- * with an internal "id" property
- * @param {object} dict - dictionary with keys and values
- */
-function dictToListWithIds(dict) {
-  return Object.entries(dict).map(
-    ([key, node]) => ({ ...node, key }),
-  );
-}
-
-/**
- * Convert property that could be a string to an array if not given as array
- * @param {object} obj - object to modify
- * @param {string} property - property to modify
- */
-function standardizeArrayProperty(obj, property) {
-  if (obj[property] && !_.isArray(obj[property])) {
-    obj[property] = [obj[property]];
-  }
-  if (obj[property] && property === 'ids') {
-    obj.id = obj.ids;
-    delete obj.ids;
-  }
-  if (obj[property] && property === 'categories') {
-    obj.category = obj.categories;
-    delete obj.categories;
-  }
-  if (obj[property] && property === 'predicates') {
-    obj.predicate = obj.predicates;
-    delete obj.predicates;
-  }
+  return object;
 }
 
 /**
@@ -81,69 +47,92 @@ function makeArray(value) {
   throw TypeError('Unexpected input. Should be either an array or string.');
 }
 
-const standardizeIDs = (o) => standardizeArrayProperty(o, 'ids');
-const standardizePredicate = (o) => standardizeArrayProperty(o, 'predicates');
-const standardizeCategory = (o) => standardizeArrayProperty(o, 'categories');
-
 /**
  * Remove empty arrays
  * @param {object} obj - object to prune
  * @param {string} property - property of object to prune
 */
 function pruneEmptyArray(obj, property) {
-  if (obj[property] && _.isArray(obj[property]) &&
-      obj[property].length === 0) {
+  if (obj[property] && Array.isArray(obj[property]) && obj[property].length === 0) {
     delete obj[property];
   }
 }
 
 /**
- * Conversion utilities between
- * different query graph representations
+ * Convert an old Reasoner standard query graph to the current TRAPI version format
+ * @param {object} qGraph - a query graph in an older format
+ * @returns {object} a query graph in the current TRAPI format
  */
-const convert = {
-  /**
-   * Convert an old Reasoner standard query graph to a newer internal representation
-   * @param {object} q - a query graph containing lists of nodes and edges
-   * @returns {object} a query graph containing objects of nodes and edges
-   */
-  reasonerToInternal(q) {
-    const internalRepresentation = {};
-    internalRepresentation.nodes = listWithIdsToDict(q.nodes);
-    internalRepresentation.edges = listWithIdsToDict(q.edges);
+function toCurrentTRAPI(qGraph) {
+  const query_graph = _.cloneDeep(qGraph);
+  // convert arrays to objects
+  if (Array.isArray(qGraph.nodes)) {
+    query_graph.nodes = arrayWithIdsToObj(qGraph.nodes);
+  } else {
+    query_graph.nodes = qGraph.nodes;
+  }
+  if (Array.isArray(qGraph.edges)) {
+    query_graph.edges = arrayWithIdsToObj(qGraph.edges);
+  } else {
+    query_graph.edges = qGraph.edges;
+  }
 
-    Object.values(internalRepresentation.nodes).forEach(standardizeIDs);
-    Object.values(internalRepresentation.nodes).forEach(standardizeCategory);
+  // convert outdated node properties
+  Object.values(query_graph.nodes).forEach((node) => {
+    if (node.curie) {
+      node.ids = node.curie;
+      delete node.curie;
+    } else if (node.id) {
+      node.ids = node.id;
+      delete node.id;
+    }
+    if (node.ids) {
+      node.ids = makeArray(node.ids);
+    }
 
-    Object.values(internalRepresentation.edges).forEach(standardizeCategory);
-    return internalRepresentation;
-  },
-  /**
-   * Convert a newer internal representation to the older Reasoner standard query graph
-   * @param {object} q - a query graph containing objects of nodes and edges
-   * @returns {object} a query graph containing a list of nodes and edges
-   */
-  internalToReasoner(q) {
-    const reasonerRepresentation = {};
-    reasonerRepresentation.nodes = dictToListWithIds(q.nodes);
-    reasonerRepresentation.edges = dictToListWithIds(q.edges);
+    if (node.type) {
+      node.categories = node.type;
+      delete node.type;
+    } else if (node.category) {
+      node.categories = node.category;
+      delete node.category;
+    }
+    if (node.categories) {
+      node.categories = makeArray(node.categories);
+    }
 
-    reasonerRepresentation.nodes.forEach((node) => {
-      pruneEmptyArray(node, 'id');
-      pruneEmptyArray(node, 'category');
-      node.id = node.key;
-      delete node.key;
-    });
+    if (typeof node.set === 'boolean') {
+      node.is_set = node.set;
+      delete node.set;
+    }
+    if (!node.name) {
+      node.name =
+        (node.ids && node.ids.length && node.ids.join(', ')) ||
+        (node.categories && node.categories.length && stringUtils.displayCategory(node.categories)) ||
+        '';
+    }
+  });
 
-    reasonerRepresentation.edges.forEach((edge) => {
-      pruneEmptyArray(edge, 'predicate');
-      edge.id = edge.key;
-      delete edge.key;
-    });
-
-    return reasonerRepresentation;
-  },
-};
+  // convert outdated edge properties
+  Object.values(query_graph.edges).forEach((edge) => {
+    if (edge.source_id) {
+      edge.subject = edge.source_id;
+      delete edge.source_id;
+    }
+    if (edge.target_id) {
+      edge.object = edge.target_id;
+      delete edge.target_id;
+    }
+    if (edge.predicate) {
+      edge.predicates = edge.predicate;
+      delete edge.predicate;
+    }
+    if (edge.predicates) {
+      edge.predicates = makeArray(edge.predicates);
+    }
+  });
+  return query_graph;
+}
 
 /**
  * Remove any empty node categories or ids or edge predicates
@@ -153,53 +142,11 @@ const convert = {
 function prune(q_graph) {
   const clonedQueryGraph = _.cloneDeep(q_graph);
   Object.keys(clonedQueryGraph.nodes).forEach((n) => {
-    pruneEmptyArray(clonedQueryGraph.nodes[n], 'category');
-    pruneEmptyArray(clonedQueryGraph.nodes[n], 'id');
-    if (clonedQueryGraph.nodes[n].id) {
-      clonedQueryGraph.nodes[n].ids = clonedQueryGraph.nodes[n].id;
-      delete clonedQueryGraph.nodes[n].id;
-      if (!Array.isArray(clonedQueryGraph.nodes[n].ids)) {
-        clonedQueryGraph.nodes[n].ids = [clonedQueryGraph.nodes[n].ids];
-      }
-    }
-    if (clonedQueryGraph.nodes[n].category) {
-      clonedQueryGraph.nodes[n].categories = clonedQueryGraph.nodes[n].category;
-      delete clonedQueryGraph.nodes[n].category;
-    }
+    pruneEmptyArray(clonedQueryGraph.nodes[n], 'categories');
+    pruneEmptyArray(clonedQueryGraph.nodes[n], 'ids');
   });
   Object.keys(clonedQueryGraph.edges).forEach((e) => {
-    pruneEmptyArray(clonedQueryGraph.edges[e], 'predicate');
-    if (clonedQueryGraph.edges[e].predicate) {
-      clonedQueryGraph.edges[e].predicates = clonedQueryGraph.edges[e].predicate;
-      delete clonedQueryGraph.edges[e].predicate;
-    }
-  });
-  return clonedQueryGraph;
-}
-
-/**
- * Standardize properties in a valid query graph
- *
- * - wraps ids, categories, and predicates in arrays
- * - adds a 'name' property to nodes
- * @param {object} q_graph - query graph object
- * @returns {{}} query graph
- */
-function standardize(q_graph) {
-  const clonedQueryGraph = _.cloneDeep(q_graph);
-  Object.keys(clonedQueryGraph.nodes).forEach((n) => {
-    const node = clonedQueryGraph.nodes[n];
-    standardizeIDs(node);
-    standardizeCategory(node);
-    if (!node.name) {
-      node.name =
-        (node.id && node.id.length && node.id.join(', ')) ||
-        (node.category && node.category.length && stringUtils.displayCategory(node.category)) ||
-        '';
-    }
-  });
-  Object.keys(clonedQueryGraph.edges).forEach((e) => {
-    standardizePredicate(clonedQueryGraph.edges[e]);
+    pruneEmptyArray(clonedQueryGraph.edges[e], 'predicates');
   });
   return clonedQueryGraph;
 }
@@ -209,39 +156,39 @@ function standardize(q_graph) {
  * @param {object} node - query graph node
  * @returns {string} human-readable id label
  */
-function getNodeIdLabel(node) {
-  if (node.id && Array.isArray(node.id)) {
-    return node.id.join(', ');
+function getTableHeaderLabel(node) {
+  if (node.ids && Array.isArray(node.ids)) {
+    return node.ids.join(', ');
   }
-  return node.id;
+  return node.ids;
 }
 
 /**
  * Convert nodes and edges objects to lists for d3
- * @param {obj} q_graph
+ * @param {obj} query_graph
  * @returns {obj} query graph with node and edge lists
  */
-function getNodeAndEdgeListsForDisplay(q_graph) {
-  const query_graph = standardize(q_graph);
+function getNodeAndEdgeListsForDisplay(query_graph) {
   const nodes = Object.entries(query_graph.nodes).map(([nodeId, obj]) => {
     let { name } = obj;
     if (!obj.name) {
-      name = obj.id && obj.id.length ? obj.id.join(', ') : stringUtils.displayCategory(obj.category);
+      name = obj.ids && obj.ids.length ? obj.ids.join(', ') : stringUtils.displayCategory(obj.categories);
     }
     if (!name) {
       name = 'Something';
     }
-    obj.category = makeArray(obj.category);
     return {
       id: nodeId,
       name,
-      category: obj.category,
+      categories: obj.categories,
+      is_set: obj.is_set,
     };
   });
   const edges = Object.entries(query_graph.edges).map(([edgeId, obj]) => (
     {
       id: edgeId,
-      predicate: obj.predicate,
+      predicates: obj.predicates,
+      // source and target are specifically for d3
       source: obj.subject,
       target: obj.object,
     }
@@ -251,12 +198,8 @@ function getNodeAndEdgeListsForDisplay(q_graph) {
 
 export default {
   getEmptyGraph,
-  convert,
-  standardizeCategory,
-  standardizePredicate,
-  standardizeIDs,
+  toCurrentTRAPI,
   prune,
-  standardize,
   getNodeAndEdgeListsForDisplay,
-  getNodeIdLabel,
+  getTableHeaderLabel,
 };

--- a/frontend/src/utils/queryGraph.js
+++ b/frontend/src/utils/queryGraph.js
@@ -146,95 +146,6 @@ const convert = {
 };
 
 /**
- * Find curve id regardless of node id order
- * @param {object[]} edgeCurves - list of edges with curve properties
- * @param {string} id - `{nodeId}--{nodeId}`
- * @returns {string} `{nodeId}--{nodeId}`
- */
-function findCurveId(edgeCurves, id) {
-  const [subject, object] = id.split('--');
-  const curveId = Object.keys(edgeCurves).find((curve) => {
-    const nodeIds = curve.split('--');
-    if (nodeIds.indexOf(subject) > -1 && nodeIds.indexOf(object) > -1) {
-      return true;
-    }
-    return false;
-  });
-  return curveId;
-}
-
-const edgeCurveProps = {
-  get: (edgeCurves, id) => {
-    const curveId = findCurveId(edgeCurves, id);
-    let flip = false;
-    if (curveId) {
-      // n0--n1 != n1--n0
-      // we need to flip in order to have all edges right side up
-      if (curveId !== id) {
-        flip = true;
-      }
-      // return existing edge curve props
-      return { indices: edgeCurves[curveId], flip };
-    }
-    // return new edge curve props
-    return { indices: [], flip };
-  },
-  set: (edgeCurves, id, val) => {
-    const curveId = findCurveId(edgeCurves, id);
-    if (curveId) {
-      edgeCurves[curveId] = val;
-    } else {
-      edgeCurves[id] = val;
-    }
-    return true;
-  },
-};
-
-/**
- * Add numEdges, index, and strokeWidth to edge objects
- *
- * **Must modify the existing edges array to keep the same reference for d3**
- * @param {object[]} edges - list of graph edges
- * @returns {object[]} list of edges with properties for d3 curves
- */
-function addEdgeCurveProperties(edges) {
-  const curveProps = new Proxy({}, edgeCurveProps);
-  edges.forEach((e, i) => {
-    const curve = curveProps[`${e.source.id}--${e.target.id}`];
-    curve.indices.push(i);
-    curveProps[`${e.source.id}--${e.target.id}`] = curve.indices;
-  });
-  edges.forEach((e, i) => {
-    const curve = curveProps[`${e.source.id}--${e.target.id}`];
-    e.numEdges = curve.indices.length;
-    const edgeIndex = curve.indices.indexOf(i);
-    e.index = edgeIndex;
-    // if an even number of edges, move first middle edge to outside
-    // to keep edges symmetrical
-    if (curve.indices.length % 2 === 0 && edgeIndex === 0) {
-      e.index = curve.indices.length - 1;
-    }
-    // if not the first index (0)
-    if (edgeIndex) {
-      // all even index should be one less and odd indices
-      // should be flipped
-      const edgeL = edgeIndex % 2;
-      if (!edgeL) {
-        e.index -= 1;
-      } else {
-        e.index = -e.index;
-      }
-    }
-    // flip curve on any inverse edges
-    if (curve.flip) {
-      e.index = -e.index;
-    }
-    e.strokeWidth = '3';
-  });
-  return edges;
-}
-
-/**
  * Remove any empty node categories or ids or edge predicates
  * @param {obj} q_graph - query graph
  * @returns query graph
@@ -344,7 +255,6 @@ export default {
   standardizeCategory,
   standardizePredicate,
   standardizeIDs,
-  addEdgeCurveProperties,
   prune,
   standardize,
   getNodeAndEdgeListsForDisplay,

--- a/frontend/src/utils/results.js
+++ b/frontend/src/utils/results.js
@@ -16,7 +16,7 @@ export function findStartingNode(query_graph) {
   const nodes = Object.entries(query_graph.nodes).map(([key, node]) => (
     {
       key,
-      pinned: node.id && Array.isArray(node.id) && node.id.length > 0,
+      pinned: node.ids && Array.isArray(node.ids) && node.ids.length > 0,
     }
   ));
   const edgeNums = queryBuilderUtils.getNumEdgesPerNode(query_graph);
@@ -94,9 +94,9 @@ function makeTableHeaders(message, colorMap) {
   const sortedNodes = sortNodes(query_graph, startingNode);
   const headerColumns = sortedNodes.map((id) => {
     const qgNode = query_graph.nodes[id];
-    const backgroundColor = colorMap(qgNode.category && Array.isArray(qgNode.category) && qgNode.category[0]);
-    const nodeIdLabel = queryGraphUtils.getNodeIdLabel(qgNode);
-    const headerText = qgNode.name || nodeIdLabel || stringUtils.displayCategory(qgNode.category) || 'Something';
+    const backgroundColor = colorMap(qgNode.categories && Array.isArray(qgNode.categories) && qgNode.categories[0]);
+    const nodeIdLabel = queryGraphUtils.getTableHeaderLabel(qgNode);
+    const headerText = qgNode.name || nodeIdLabel || stringUtils.displayCategory(qgNode.categories) || 'Something';
     return {
       Header: `${headerText} (${id})`,
       color: backgroundColor,
@@ -105,7 +105,7 @@ function makeTableHeaders(message, colorMap) {
       Cell: ({ value }) => {
         if (value.length > 1) {
           // this is a set
-          return `Set of ${stringUtils.displayCategory(qgNode.category)} [${value.length}]`;
+          return `Set of ${stringUtils.displayCategory(qgNode.categories)} [${value.length}]`;
         }
         return knowledge_graph.nodes[value[0].id].name || value[0].id;
       },

--- a/frontend/src/utils/strings.js
+++ b/frontend/src/utils/strings.js
@@ -22,24 +22,17 @@ function toSnakeCase(str) {
 
 /**
  * Convert to pascal case with biolink curie format
- * @param {string} str string to convert to pascal case
+ * @param {string} str - string to convert to pascal case
  */
 function toPascalCase(str) {
   const camelCaseStr = _.camelCase(str);
-  const pascalCategory = `${camelCaseStr.charAt(0).toUpperCase()}${camelCaseStr.slice(1)}`;
-  return pascalCategory;
-}
-
-function toArray(categories) {
-  if (!Array.isArray(categories)) {
-    return [categories];
-  }
-  return categories;
+  const pascalCase = `${camelCaseStr.charAt(0).toUpperCase()}${camelCaseStr.slice(1)}`;
+  return pascalCase;
 }
 
 /**
  * Convert category from biolink into snake case
- * @param {string} category biolink category to ingest
+ * @param {string} category - biolink category to ingest
  */
 function nodeFromBiolink(category) {
   return category && `biolink:${toPascalCase(category)}`;
@@ -47,7 +40,7 @@ function nodeFromBiolink(category) {
 
 /**
  * Convert type from biolink into snake case
- * @param {string} type biolink type to ingest
+ * @param {string} type - biolink type to ingest
  * @returns {string} 'biolink:snake_case'
  */
 function edgeFromBiolink(type) {
@@ -56,7 +49,7 @@ function edgeFromBiolink(type) {
 
 /**
  * Convert label into prettier display
- * @param {string|array} arg string or array of wanted pretty display
+ * @param {string|array} arg - string or array of wanted pretty display
  * will only grab the first item in array
  */
 function displayCategory(arg) {
@@ -71,8 +64,8 @@ function displayCategory(arg) {
     // remove 'biolink:'
     const [, pascalCategory] = label.split(':');
     // split pascal case
-    const out = pascalCategory.split(/(?=[A-Z][a-z])/g);
-    return out.join(' ');
+    const splitCategory = pascalCategory.split(/(?=[A-Z][a-z])/g);
+    return splitCategory.join(' ');
   } catch (err) {
     return '';
   }
@@ -80,25 +73,25 @@ function displayCategory(arg) {
 
 /**
  * Readable version of 'Set of {category}'
- * @param {string} category node category
+ * @param {string} category - node category
  * @returns Set of {category}
  */
-function setify(cat) {
-  let category = displayCategory(cat);
-  if (category.endsWith('ay')) {
+function setify(category) {
+  let pluralCategory = displayCategory(category);
+  if (pluralCategory.endsWith('ay')) {
     // Pathway
-    category = `${category}s`;
-  } else if (category.endsWith('y')) {
-    category = `${category.slice(0, category.length - 1)}ies`;
-  } else if (category.endsWith('ms')) {
+    pluralCategory = `${pluralCategory}s`;
+  } else if (pluralCategory.endsWith('y')) {
+    pluralCategory = `${pluralCategory.slice(0, pluralCategory.length - 1)}ies`;
+  } else if (pluralCategory.endsWith('ms')) {
     // Population Of Individual Organisms
-    category = `${category}`;
-  } else if (category.endsWith('s')) {
-    category = `${category}es`;
+    pluralCategory = `${pluralCategory}`;
+  } else if (pluralCategory.endsWith('s')) {
+    pluralCategory = `${pluralCategory}es`;
   } else {
-    category = `${category}s`;
+    pluralCategory = `${pluralCategory}s`;
   }
-  return `Set of ${category}`;
+  return `Set of ${pluralCategory}`;
 }
 
 function displayPredicate(arg) {
@@ -144,7 +137,6 @@ export default {
   toCamelCase,
   toPascalCase,
   toSnakeCase,
-  toArray,
   prettyDisplay,
   displayPredicate,
   displayCategory,

--- a/frontend/tests/common/test_message.json
+++ b/frontend/tests/common/test_message.json
@@ -7,7 +7,7 @@
           "is_set": true
         },
         "n1": {
-          "id": ["MONDO:0005737"],
+          "ids": ["MONDO:0005737"],
           "is_set": false
         }
       },
@@ -33,7 +33,7 @@
         "1": {
           "subject": "1",
           "object": "2",
-          "predicate": []
+          "predicates": []
         }
       }
     },


### PR DESCRIPTION
There should be very minimal changes to the UI, as these changes are mostly to the internal message representation.

UI:
- When editing the JSON in the query builder, properties should be `ids`, `categories`, and `predicates`
- When downloading answers from the answer page, properties in the query graph should be `ids`, `categories`, and `predicates`

Closes #212 