### PR TITLE
Add SSL support to deployment environments

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,8 @@
+# External ARAs
+STRIDER=https://strider.renci.org/1.1
+ROBOKOP=http://robokop.renci.org:7092
+
+# External Services
+NODE_NORMALIZER=https://nodenormalization-sri.renci.org/1.1/
+NAME_RESOLVER=https://name-resolution-sri.renci.org/
+BIOLINK=https://raw.githubusercontent.com/biolink/biolink-model/1.8.2/biolink-model.yaml

--- a/.env
+++ b/.env
@@ -1,8 +1,0 @@
-# External ARAs
-STRIDER=https://strider.renci.org/1.1
-ROBOKOP=http://robokop.renci.org:7092
-
-# External Services
-NODE_NORMALIZER=https://nodenormalization-sri.renci.org/1.1/
-NAME_RESOLVER=https://name-resolution-sri.renci.org/
-BIOLINK=https://raw.githubusercontent.com/biolink/biolink-model/1.8.2/biolink-model.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vscode/
 robokache-data/
 node_modules/
+.env

--- a/README.md
+++ b/README.md
@@ -35,11 +35,7 @@ Deploy using the following command (recommended):
 docker-compose -f docker-compose.base.yml -f docker-compose.prod.yml up --build --renew-anon-volumes --abort-on-container-exit
 ```
 
-You may also use the management script (not recommended for actual deployment but may be useful for local testing of the production environment):
-
-```bash
-node manage.js local-prod
-```
+External services can be updated by editing the variables in the `.env` file
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -8,12 +8,13 @@ A friendly interface for users to create, upload, ask, and view biomedical quest
 ### Setup
 
 1. Clone this repository locally.
-1. Install the following dependencies.
+2. Install the following dependencies.
     * [Docker](https://docs.docker.com/get-docker/)
     * [Docker Compose](https://docs.docker.com/compose/install/)
     * Optional to use management script:
 		* Install [Node.js](https://nodejs.org/)
 		* Run `npm install`
+3. (Optional) Add an `.env` file to the root directory to override any external service urls.
 
 ### Run
 
@@ -35,7 +36,7 @@ Deploy using the following command (recommended):
 docker-compose -f docker-compose.base.yml -f docker-compose.prod.yml up --build --renew-anon-volumes --abort-on-container-exit
 ```
 
-External services can be updated by editing the variables in the `.env` file
+External service urls can be changed in an `.env` file in the root directory.
 
 ## Contributing
 

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -3,14 +3,13 @@ version: '3.5'
 services:
   proxy:
     build: proxy/
-    ports:
-      - "7080:7080"
+    env_file:
+      - ./.env
     environment:
       DNS_SERVER: 127.0.0.11
-      ROBOKACHE_URL: http://robokache:8080
-      FRONTEND_URL: http://frontend:7080
-      QUERYDISPATCHER_URL: http://query-dispatcher
-      STRIDER_URL: https://strider.renci.org/1.1
+      FRONTEND: http://frontend:7080
+      QUERY_DISPATCHER: http://query-dispatcher
+      ROBOKACHE: http://robokache:8080
   frontend:
     build: frontend/
   robokache:
@@ -19,6 +18,7 @@ services:
       - ./robokache-data:/app/data
   query-dispatcher:
     build: query-dispatcher/
+    env_file:
+      - ./.env
     environment:
-      ROBOKACHE_URL: http://robokache:8080
-      STRIDER_URL: https://strider.renci.org/1.1
+      ROBOKACHE: http://robokache:8080

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -3,13 +3,18 @@ version: '3.5'
 services:
   proxy:
     build: proxy/
-    env_file:
-      - ./.env
     environment:
       DNS_SERVER: 127.0.0.11
       FRONTEND: http://frontend:7080
       QUERY_DISPATCHER: http://query-dispatcher
       ROBOKACHE: http://robokache:8080
+      # https://docs.docker.com/compose/environment-variables/#substitute-environment-variables-in-compose-files
+      # default external service urls with option to override with .env file
+      STRIDER: ${STRIDER:-https://strider.renci.org/1.1}
+      ROBOKOP: ${ROBOKOP:-http://robokop.renci.org:7092}
+      NODE_NORMALIZER: ${NODE_NORMALIZER:-https://nodenormalization-sri.renci.org/1.1/}
+      NAME_RESOLVER: ${NAME_RESOLVER:-https://name-resolution-sri.renci.org/}
+      BIOLINK: ${BIOLINK:-https://raw.githubusercontent.com/biolink/biolink-model/1.8.2/biolink-model.yaml}
   frontend:
     build: frontend/
   robokache:
@@ -18,7 +23,6 @@ services:
       - ./robokache-data:/app/data
   query-dispatcher:
     build: query-dispatcher/
-    env_file:
-      - ./.env
     environment:
       ROBOKACHE: http://robokache:8080
+      ROBOKOP: ${ROBOKOP:-http://robokop.renci.org:7092}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,6 +1,12 @@
 version: '3.5'
 
 services:
+  proxy:
+    ports:
+      - "7080:7080"
+    volumes:
+      # use dev server block in nginx
+      - ./proxy/dev_server.conf:/etc/nginx/templates/server.conf.template
   frontend:
     build:
       dockerfile: Dockerfile.dev
@@ -16,10 +22,4 @@ services:
     volumes:
       - ./query-dispatcher:/app
       - /app/node_modules
-    environment:
-      # deployed locally, we need to look at external robokop ara url
-      ROBOKOP_URL: http://robokop.renci.org:7092
     command: npm run dev
-  proxy:
-    environment:
-      ROBOKOP_URL: http://robokop.renci.org:7092

--- a/docker-compose.qgraph.yml
+++ b/docker-compose.qgraph.yml
@@ -1,15 +1,18 @@
 version: '3.5'
 
 services:
+  proxy:
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      # need to copy both live and archive because live is symlink to archive
+      - /etc/letsencrypt/live/qgraph.org/:/etc/nginx/ssl/certs/
+      - /etc/letsencrypt/archive/qgraph.org/:/etc/nginx/archive/qgraph.org/
+      # use qgraph server block in nginx
+      - ./proxy/qgraph_server.conf:/etc/nginx/templates/server.conf.template
   frontend:
     build:
       dockerfile: Dockerfile.prod
     environment:
       BRAND: qgraph
-  proxy:
-    environment:
-      # deployed on AWS, we need to use external robokop ara url
-      ROBOKOP_URL: http://robokop.renci.org:7092
-  query-dispatcher:
-    environment:
-      ROBOKOP_URL: http://robokop.renci.org:7092

--- a/docker-compose.robokop.yml
+++ b/docker-compose.robokop.yml
@@ -1,15 +1,15 @@
 version: '3.5'
 
 services:
+  proxy:
+    ports:
+      - "7080:7080"
+    volumes:
+      - /local/certs:/etc/nginx/ssl/certs
+      # use robokop server block in nginx
+      - ./proxy/robokop_server.conf:/etc/nginx/templates/server.conf.template
   frontend:
     build:
       dockerfile: Dockerfile.prod
     environment:
       BRAND: robokop
-  proxy:
-    environment:
-      # deployed on renci servers, we need to look at local docker container
-      ROBOKOP_URL: http://robokop-ara:7092
-  query-dispatcher:
-    environment:
-      ROBOKOP_URL: http://robokop-ara:7092

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -3,7 +3,7 @@ events {}
 http {
   sendfile on;
   server {
-    listen 80;
+    listen 7080;
     location / {
       root   /app;
       index  index.html;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "robokop",
-  "productName": "ROBOKOP",
+  "name": "qgraph",
+  "productName": "qgraph_ui",
   "version": "0.0.1",
-  "description": "ROBOKOP - A user interface for biomedical knowledge graph construction and reasoning.",
-  "author": "ROBOKOP Team",
+  "description": "qgraph - A user interface for biomedical knowledge graph construction and reasoning.",
+  "author": "CoVar",
   "license": "MIT",
   "devDependencies": {
     "@babel/core": "^7.10.5",
@@ -96,6 +96,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/ncats-gamma/robokop.git"
+    "url": "git://github.com/NCATS-Gamma/qgraph.git"
   }
 }

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -5,9 +5,6 @@
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <link rel="shortcut icon" href="favicon.ico">
 
-        <!-- Google Signin -->
-        <script src="https://apis.google.com/js/platform.js"></script>
-
         <title>QGRAPH</title>
     </head>
       

--- a/frontend/src/API/biolink.js
+++ b/frontend/src/API/biolink.js
@@ -3,13 +3,15 @@ import yaml from 'js-yaml';
 
 import utils from './utils';
 
+const biolink_url = `${window.location.origin}/api/external/biolink`;
+
 const routes = {
   /**
    * Get biolink model specification
    */
   async getModelSpecification() {
     const config = {
-      url: 'https://raw.githubusercontent.com/biolink/biolink-model/1.8.2/biolink-model.yaml',
+      url: biolink_url,
       method: 'GET',
     };
     let response;

--- a/manage.js
+++ b/manage.js
@@ -46,17 +46,6 @@ yargs(hideBin(process.argv))
   })
 
   .command({
-    command: 'local-prod',
-    describe: 'This command starts up a development environment. The development environment is started through docker-compose and is visible at http://localhost.',
-    handler: () => {
-      runCommand(`
-         ${baseCommand} -f docker-compose.prod.yml
-         up --build --renew-anon-volumes --abort-on-container-exit
-      `);
-    },
-  })
-
-  .command({
     command: 'test',
     describe: 'Runs tests through docker-compose and exits',
     handler: () => {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "manage",
   "type": "module",
   "version": "1.0.0",
-  "description": "Management script for automating robokop dev commands",
+  "description": "Management script for automating qgraph dev commands",
   "main": "manage.js",
   "dependencies": {
     "colors": "^1.4.0",
@@ -13,19 +13,19 @@
   },
   "scripts": {
 	  "dev"  : "node manage.js dev",
-	  "prod" : "node manage.js local-prod",
+	  "hot" : "node manage.js dev --hotReload",
 	  "test" : "node manage.js test",
 	  "frontend-lint" : "node manage.js frontend lint",
 	  "frontend-lint-summary" : "node manage.js frontend lint-summary"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/NCATS-Gamma/robokop-rewrite.git"
+    "url": "git+https://github.com/NCATS-Gamma/qgraph.git"
   },
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/NCATS-Gamma/robokop-rewrite/issues"
+    "url": "https://github.com/NCATS-Gamma/qgraph/issues"
   },
-  "homepage": "https://github.com/NCATS-Gamma/robokop-rewrite#readme"
+  "homepage": "https://github.com/NCATS-Gamma/qgraph#readme"
 }

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -8,4 +8,9 @@ ENV NGINX_ENVSUBST_OUTPUT_DIR /etc/nginx
 
 COPY json_error.conf /etc/nginx/json_error.conf
 
+# All files with env vars in them need to be put into templates folder so
+# envsubst gets called on them automatically.
+# envsubst replaces all variables with env values.
+# These templates are then output to /etc/nginx
+COPY routes.conf /etc/nginx/templates/routes.conf.template
 COPY nginx.conf /etc/nginx/templates/nginx.conf.template

--- a/proxy/dev_server.conf
+++ b/proxy/dev_server.conf
@@ -1,11 +1,3 @@
-# Redirect from http to https
-server {
-    listen      7081;
-    server_name _;
-
-    return 301 https://$host:7080$request_uri;
-}
-
 server {
     listen 7080;
 

--- a/proxy/dev_server.conf
+++ b/proxy/dev_server.conf
@@ -1,0 +1,22 @@
+# Redirect from http to https
+server {
+    listen      7081;
+    server_name _;
+
+    return 301 https://$host:7080$request_uri;
+}
+
+server {
+    listen 7080;
+
+    access_log /dev/stdout combined_no_query if=$loggable;
+
+    # Disable timeouts, some ARAs might take a while
+    proxy_read_timeout 1d;
+    proxy_connect_timeout 1d;
+    proxy_send_timeout 1d;
+
+    client_max_body_size 0;
+
+    include routes.conf;
+}

--- a/proxy/nginx.conf
+++ b/proxy/nginx.conf
@@ -23,55 +23,5 @@ http {
 	# Disable caching
 	if_modified_since off;
 
-	server {
-		listen 7080;
-
-		access_log /dev/stdout combined_no_query if=$loggable;
-
-		# Disable timeouts, some ARAs might take a while
-		proxy_read_timeout 1d;
-		proxy_connect_timeout 1d;
-		proxy_send_timeout 1d;
-
-		client_max_body_size 0;
-
-		# Return 500 errors as JSON
-		include json_error.conf;
-
-		location / {
-			set	$url ${FRONTEND_URL};
-			proxy_pass $url;
-		}
-
-		location ~ /api/queryDispatcher/(.*) {
-			set	$url ${QUERYDISPATCHER_URL}/;
-			proxy_pass $url$1$is_args$args;
-		}
-
-		location ~ /api/robokache/(.*) {
-			set	$url ${ROBOKACHE_URL}/api/;
-			proxy_pass $url$1$is_args$args;
-		}
-
-		location ~ /api/external/strider/(.*) {
-			set	$url ${STRIDER_URL}/;
-			proxy_pass $url$1$is_args$args;
-		}
-
-		location ~ /api/external/robokop/(.*) {
-			set $url ${ROBOKOP_URL}/;
-			proxy_pass $url$1$is_args$args;
-		}
-
-		location ~ /api/external/nodeNormalization/(.*) {
-			set $url https://nodenormalization-sri.renci.org/1.1/;
-			proxy_pass $url$1$is_args$args;
-		}
-
-		location ~ /api/external/nameResolver/(.*) {
-			set $url https://name-resolution-sri.renci.org/;
-			proxy_pass $url$1$is_args$args;
-		}
-	}
-
+	include server.conf;
 }

--- a/proxy/qgraph_server.conf
+++ b/proxy/qgraph_server.conf
@@ -1,0 +1,29 @@
+# Redirect from http to https
+server {
+    listen      80;
+    server_name _;
+
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    # http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_certificate
+    # shouldn't use variables for certificate paths
+    ssl_certificate     /etc/nginx/ssl/certs/fullchain.pem;
+    ssl_certificate_key /etc/nginx/ssl/certs/privkey.pem;
+    ssl_protocols       TLSv1.2;
+
+    access_log /dev/stdout combined_no_query if=$loggable;
+
+    # Disable timeouts, some ARAs might take a while
+    proxy_read_timeout 1d;
+    proxy_connect_timeout 1d;
+    proxy_send_timeout 1d;
+
+    client_max_body_size 0;
+
+    include routes.conf;
+}

--- a/proxy/robokop_server.conf
+++ b/proxy/robokop_server.conf
@@ -1,0 +1,25 @@
+server {
+    listen 7080 ssl;
+    listen [::]:7080 ssl;
+
+    # Redirect from http to https
+    # https://ma.ttias.be/force-redirect-http-https-custom-port-nginx/
+    error_page  497 https://$host:7080$request_uri;
+
+    # http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_certificate
+    # shouldn't use variables for certificate paths
+    ssl_certificate     /etc/nginx/ssl/certs/tls.crt;
+    ssl_certificate_key /etc/nginx/ssl/certs/tls.key;
+    ssl_protocols       TLSv1.2;
+
+    access_log /dev/stdout combined_no_query if=$loggable;
+
+    # Disable timeouts, some ARAs might take a while
+    proxy_read_timeout 1d;
+    proxy_connect_timeout 1d;
+    proxy_send_timeout 1d;
+
+    client_max_body_size 0;
+
+    include routes.conf;
+}

--- a/proxy/routes.conf
+++ b/proxy/routes.conf
@@ -1,0 +1,42 @@
+# Return 500 errors as JSON
+include json_error.conf;
+
+location / {
+    set	$url ${FRONTEND};
+    proxy_pass $url;
+}
+
+location ~ /api/queryDispatcher/(.*) {
+    set	$url ${QUERY_DISPATCHER}/;
+    proxy_pass $url$1$is_args$args;
+}
+
+location ~ /api/robokache/(.*) {
+    set	$url ${ROBOKACHE}/api/;
+    proxy_pass $url$1$is_args$args;
+}
+
+location ~ /api/external/strider/(.*) {
+    set	$url ${STRIDER}/;
+    proxy_pass $url$1$is_args$args;
+}
+
+location ~ /api/external/robokop/(.*) {
+    set $url ${ROBOKOP}/;
+    proxy_pass $url$1$is_args$args;
+}
+
+location ~ /api/external/nodeNormalization/(.*) {
+    set $url ${NODE_NORMALIZER};
+    proxy_pass $url$1$is_args$args;
+}
+
+location ~ /api/external/nameResolver/(.*) {
+    set $url ${NAME_RESOLVER};
+    proxy_pass $url$1$is_args$args;
+}
+
+location ~ /api/external/biolink {
+    set $url ${BIOLINK};
+    proxy_pass $url;
+}

--- a/query-dispatcher/robokache.js
+++ b/query-dispatcher/robokache.js
@@ -1,7 +1,7 @@
 const axios = require('axios');
 const { handleAxiosError } = require('./utils');
 
-const base_url = `${process.env.ROBOKACHE_URL}/api/`;
+const base_url = `${process.env.ROBOKACHE}/api/`;
 
 const baseRoutes = {
   async getDocumentData(doc_id, token) {

--- a/query-dispatcher/routes.js
+++ b/query-dispatcher/routes.js
@@ -8,7 +8,7 @@ const { handleAxiosError } = require('./utils');
 //                    'http://robokop.renci.org:4868/answer';
 // const strider = process.env.STRIDER_URL ||
 //                     'http://robokop.renci.org:5781';
-const robokop = process.env.ROBOKOP_URL || 'http://robokop.renci.org:7092';
+const robokop = process.env.ROBOKOP || 'http://robokop.renci.org:7092';
 
 router.route('/answer')
   .post(async (req, res) => {


### PR DESCRIPTION
Update nginx configuration to support multiple deployment environments, each with its own SSL certs.

See https://qgraph.org and https://robokop.renci.org:7080

- Both have http to https redirect
- Both are https
- Auth0 sign in works in both environments