### PR TITLE
Fix how brand is passed from docker to react

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -10,8 +10,8 @@ services:
   frontend:
     build:
       dockerfile: Dockerfile.dev
-    environment:
-      BRAND: qgraph
+      args:
+        BRAND: qgraph
     volumes:
       - ./frontend:/app
       # Mount this in an anonymous volume so that the locally available node_modules

--- a/docker-compose.qgraph.yml
+++ b/docker-compose.qgraph.yml
@@ -14,5 +14,5 @@ services:
   frontend:
     build:
       dockerfile: Dockerfile.prod
-    environment:
-      BRAND: qgraph
+      args:
+        BRAND: qgraph

--- a/docker-compose.robokop.yml
+++ b/docker-compose.robokop.yml
@@ -11,5 +11,5 @@ services:
   frontend:
     build:
       dockerfile: Dockerfile.prod
-    environment:
-      BRAND: robokop
+      args:
+        BRAND: robokop

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -4,6 +4,6 @@ services:
   frontend:
     build:
       dockerfile: Dockerfile.test
-    environment:
-      BRAND: qgraph
+      args:
+        BRAND: qgraph
     command: npm run test:cov

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -4,6 +4,10 @@ FROM node:latest as build-stage
 # Create a folder to add the code to
 WORKDIR /app
 
+# Read brand from args and set in environment
+ARG BRAND
+ENV BRAND $BRAND
+
 # Copy in package.json and package-lock.json
 COPY package*.json ./
 

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -7,6 +7,10 @@ LABEL org.opencontainers.image.source https://github.com/NCATS-Gamma/qgraph
 # Create a folder to add the code to
 WORKDIR /app
 
+# Read brand from args and set in environment
+ARG BRAND
+ENV BRAND $BRAND
+
 # Copy in package.json and package-lock.json
 COPY package*.json ./
 # Install dependencies

--- a/frontend/Dockerfile.test
+++ b/frontend/Dockerfile.test
@@ -4,6 +4,10 @@ FROM node:latest as build-stage
 # Create a folder to add the code to
 WORKDIR /app
 
+# Read brand from args and set in environment
+ARG BRAND
+ENV BRAND $BRAND
+
 # Copy in package.json and package-lock.json
 COPY package*.json ./
 


### PR DESCRIPTION
The `environment` property wasn't passing the BRAND into the frontend container correctly, so `process.env.BRAND` was always undefined. Passing BRAND as an ARG into the Dockerfiles seems to do the trick.