### PR TITLE
Undo query dispatcher routing through nginx proxy

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -25,4 +25,7 @@ services:
   query-dispatcher:
     build: query-dispatcher/
     environment:
-      PROXY: ${PROXY:-http://proxy}
+      ROBOKACHE: http://robokache:8080
+      STRIDER: ${STRIDER:-https://strider.renci.org/1.2}
+      ARAGORN: ${ARAGORN:-https://aragorn.renci.org/1.2}
+      ROBOKOP: ${ROBOKOP:-http://robokop.renci.org:7092}

--- a/frontend/src/API/utils.js
+++ b/frontend/src/API/utils.js
@@ -11,6 +11,9 @@ function handleAxiosError(error) {
     } else if (_.isString(error.response.data)) {
       // Not a JSON response so let's use it as a string
       output.message = `${axiosErrorPrefix} ${error.response.data}`;
+    } else if (error.response.data.detail) {
+      // Robokop ARA returns errors with a detail field
+      output.message = `${axiosErrorPrefix} ${error.response.data.detail}`;
     } else {
       // Not sure what to do here, just say it's unparseable.
       output.message = `${axiosErrorPrefix} Unparseable error response.`;

--- a/frontend/src/pages/queryBuilder/QueryBuilder.jsx
+++ b/frontend/src/pages/queryBuilder/QueryBuilder.jsx
@@ -43,8 +43,9 @@ export default function QueryBuilder() {
    */
   async function onQuickSubmit() {
     pageStatus.setLoading('Fetching answer, this may take a while');
+    const ara_url = ARAs[ara];
     const prunedQueryGraph = queryGraphUtils.prune(queryBuilder.query_graph);
-    const response = await API.ara.getAnswer(ARAs[ara], { message: { query_graph: prunedQueryGraph } });
+    const response = await API.ara.getAnswer(ara_url, { message: { query_graph: prunedQueryGraph } });
 
     if (response.status === 'error') {
       const failedToAnswer = 'Please try asking this question later.';
@@ -72,7 +73,7 @@ export default function QueryBuilder() {
    * @returns {object} response
    */
   async function fetchAnswer(questionId, accessToken) {
-    let response = await API.queryDispatcher.getAnswer(ARAs[ara], questionId, accessToken);
+    let response = await API.queryDispatcher.getAnswer(ara, questionId, accessToken);
     if (response.status === 'error') {
       return response;
     }

--- a/query-dispatcher/robokache.js
+++ b/query-dispatcher/robokache.js
@@ -1,12 +1,12 @@
 const axios = require('axios');
 const { handleAxiosError } = require('./utils');
 
-const base_url = `${process.env.PROXY}/api/robokache`;
+const base_url = process.env.ROBOKACHE;
 
 const baseRoutes = {
   async getDocumentData(doc_id, token) {
     const config = {
-      url: `${base_url}/document/${doc_id}/data`,
+      url: `${base_url}/api/document/${doc_id}/data`,
       method: 'GET',
       withCredentials: true,
       headers: {},
@@ -23,7 +23,7 @@ const baseRoutes = {
   },
   async setDocumentData(doc_id, newData, token) {
     const config = {
-      url: `${base_url}/document/${doc_id}/data`,
+      url: `${base_url}/api/document/${doc_id}/data`,
       method: 'PUT',
       data: newData,
       withCredentials: true,
@@ -40,7 +40,7 @@ const baseRoutes = {
 
   async createDocument(doc, token) {
     const config = {
-      url: `${base_url}/document`,
+      url: `${base_url}/api/document`,
       method: 'POST',
       data: doc,
       withCredentials: true,

--- a/query-dispatcher/routes.js
+++ b/query-dispatcher/routes.js
@@ -3,6 +3,7 @@ const axios = require('axios');
 
 const robokache = require('./robokache');
 const { handleAxiosError } = require('./utils');
+const aras = require('./services');
 
 router.route('/answer')
   .post(async (req, res) => {
@@ -13,7 +14,7 @@ router.route('/answer')
         return res.send(response);
       }
       const message = response;
-      const ara_url = `${process.env.PROXY}/${new URL(ara).pathname}`;
+      const ara_url = aras[ara];
       const config = {
         method: 'POST',
         url: ara_url,
@@ -24,7 +25,7 @@ router.route('/answer')
 
       let answer;
       try {
-        // Go ask Messenger for an answer
+        // Go ask ARA for an answer
         response = await axios(config);
 
         // Validate json
@@ -33,7 +34,7 @@ router.route('/answer')
         } catch (error) {
           answer = {
             status: 'error',
-            message: 'Recieved unparseable JSON response from Messenger',
+            message: `Recieved unparseable JSON response from ${ara}`,
           };
         }
       } catch (err) {

--- a/query-dispatcher/services.js
+++ b/query-dispatcher/services.js
@@ -1,0 +1,14 @@
+/**
+ * @file Central location of all API service URLs.
+ */
+
+// External ARAs
+const strider = `${process.env.STRIDER}/query`;
+const aragorn = `${process.env.ARAGORN}/query`;
+const robokop = `${process.env.ROBOKOP}/query`;
+
+module.exports = {
+  strider,
+  aragorn,
+  robokop,
+};


### PR DESCRIPTION
Due to ssl, calling the proxy from query dispatcher wasn't right.
So now query dispatcher talks directly to ARAs again.